### PR TITLE
Add basic arithmetic operations (+, -, *)

### DIFF
--- a/com/example/metta/atom/AbstractBinaryOperatorAtom.java
+++ b/com/example/metta/atom/AbstractBinaryOperatorAtom.java
@@ -1,0 +1,67 @@
+package com.example.metta.atom;
+
+import com.example.metta.interpreter.InterpreterContext;
+import com.example.metta.types.Type; // Assuming Type.UNDEFINED is acceptable for now
+
+import java.util.Collections;
+import java.util.List;
+
+public abstract class AbstractBinaryOperatorAtom extends GroundedAtom implements Executable {
+
+    public AbstractBinaryOperatorAtom(String symbol) {
+        super(symbol);
+    }
+
+    // Abstract method to be implemented by concrete operator classes
+    protected abstract Number performOperation(Number a, Number b);
+
+    // Optional: Integer-specific operation for precision, if needed.
+    // If subclasses can rely on Number and casting, this might not be strictly necessary.
+    // For now, let's assume performOperation(Number, Number) is sufficient and handles mixed types.
+
+    @Override
+    public List<Atom> execute(InterpreterContext context, List<Atom> args) {
+        if (args.size() != 2) {
+            // System.err.println("Error: " + getClass().getSimpleName() + " expects 2 arguments, got " + args.size());
+            return Collections.singletonList(
+                new ExpressionAtom(List.of(MettaSymbols.ERROR_SYMBOL, new SymbolAtom("IncorrectArguments"), this))
+            );
+        }
+
+        Atom arg1 = args.get(0);
+        Atom arg2 = args.get(1);
+
+        if (!(arg1 instanceof GroundedAtom) || !(((GroundedAtom) arg1).getGroundedObject() instanceof Number) ||
+            !(arg2 instanceof GroundedAtom) || !(((GroundedAtom) arg2).getGroundedObject() instanceof Number)) {
+            // System.err.println("Error: " + getClass().getSimpleName() + " expects numeric arguments. Got: " + arg1 + ", " + arg2);
+            return Collections.singletonList(
+                new ExpressionAtom(List.of(MettaSymbols.ERROR_SYMBOL, new SymbolAtom("NonNumericArguments"), this, arg1, arg2))
+            );
+        }
+
+        Number val1 = (Number) ((GroundedAtom) arg1).getGroundedObject();
+        Number val2 = (Number) ((GroundedAtom) arg2).getGroundedObject();
+
+        try {
+            Number result = performOperation(val1, val2);
+            return Collections.singletonList(new GroundedAtom(result, Type.UNDEFINED)); // Assuming Type.UNDEFINED for now
+        } catch (ArithmeticException e) {
+            // System.err.println("Error: ArithmeticException in " + getClass().getSimpleName() + ": " + e.getMessage());
+             return Collections.singletonList(
+                new ExpressionAtom(List.of(MettaSymbols.ERROR_SYMBOL, new SymbolAtom("ArithmeticError"), new SymbolAtom(e.getMessage()), this, arg1, arg2))
+            );
+        }
+    }
+
+    // equals method should be implemented by concrete subclasses if they don't add fields.
+    // If they are stateless beyond the symbol, then:
+    // @Override
+    // public boolean equals(Object obj) {
+    //     if (this == obj) return true;
+    //     if (obj == null || getClass() != obj.getClass()) return false;
+    //     AbstractBinaryOperatorAtom other = (AbstractBinaryOperatorAtom) obj;
+    //     return this.getSymbol().equals(other.getSymbol());
+    // }
+    // However, GroundedAtom's equals already checks based on grounded object (symbol for us) and type.
+    // Let's rely on GroundedAtom's equals and specific implementations if needed.
+}

--- a/com/example/metta/atom/AddAtom.java
+++ b/com/example/metta/atom/AddAtom.java
@@ -1,0 +1,42 @@
+package com.example.metta.atom;
+
+import com.example.metta.types.Type;
+// InterpreterContext, List, Collections might not be strictly needed here anymore
+// but leaving them for now.
+import com.example.metta.interpreter.InterpreterContext;
+import java.util.List;
+import java.util.Collections;
+
+public class AddAtom extends AbstractBinaryOperatorAtom {
+
+    public AddAtom() {
+        super("+");
+    }
+
+    @Override
+    protected Number performOperation(Number a, Number b) {
+        // Promote to double if either is double, otherwise perform integer addition.
+        if (a instanceof Double || b instanceof Double) {
+            return a.doubleValue() + b.doubleValue();
+        } else if (a instanceof Float || b instanceof Float) {
+            // Handle floats explicitly if necessary, or let them be promoted to double
+            return a.floatValue() + b.floatValue();
+        } else if (a instanceof Long || b instanceof Long) {
+            return a.longValue() + b.longValue();
+        } else {
+            // Default to integer addition for Integer, Short, Byte
+            return a.intValue() + b.intValue();
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        // Rely on GroundedAtom's equals, which checks the symbol for stateless atoms.
+        // This implementation assumes AddAtom has no additional state beyond its symbol.
+        if (this == obj) return true;
+        if (!(obj instanceof AddAtom)) return false;
+        // If GroundedAtom's equals considers the class type, this is fine.
+        // If it only considers the grounded object (symbol), this is also fine.
+        return super.equals(obj);
+    }
+}

--- a/com/example/metta/atom/MultiplyAtom.java
+++ b/com/example/metta/atom/MultiplyAtom.java
@@ -1,0 +1,35 @@
+package com.example.metta.atom;
+
+import com.example.metta.types.Type;
+import com.example.metta.interpreter.InterpreterContext;
+import java.util.List;
+import java.util.Collections;
+
+public class MultiplyAtom extends AbstractBinaryOperatorAtom {
+
+    public MultiplyAtom() {
+        super("*");
+    }
+
+    @Override
+    protected Number performOperation(Number a, Number b) {
+        // Promote to double if either is double, otherwise perform integer multiplication.
+        if (a instanceof Double || b instanceof Double) {
+            return a.doubleValue() * b.doubleValue();
+        } else if (a instanceof Float || b instanceof Float) {
+            return a.floatValue() * b.floatValue();
+        } else if (a instanceof Long || b instanceof Long) {
+            return a.longValue() * b.longValue();
+        } else {
+            // Default to integer multiplication for Integer, Short, Byte
+            return a.intValue() * b.intValue();
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof MultiplyAtom)) return false;
+        return super.equals(obj);
+    }
+}

--- a/com/example/metta/atom/SubtractAtom.java
+++ b/com/example/metta/atom/SubtractAtom.java
@@ -1,0 +1,35 @@
+package com.example.metta.atom;
+
+import com.example.metta.types.Type;
+import com.example.metta.interpreter.InterpreterContext;
+import java.util.List;
+import java.util.Collections;
+
+public class SubtractAtom extends AbstractBinaryOperatorAtom {
+
+    public SubtractAtom() {
+        super("-");
+    }
+
+    @Override
+    protected Number performOperation(Number a, Number b) {
+        // Promote to double if either is double, otherwise perform integer subtraction.
+        if (a instanceof Double || b instanceof Double) {
+            return a.doubleValue() - b.doubleValue();
+        } else if (a instanceof Float || b instanceof Float) {
+            return a.floatValue() - b.floatValue();
+        } else if (a instanceof Long || b instanceof Long) {
+            return a.longValue() - b.longValue();
+        } else {
+            // Default to integer subtraction for Integer, Short, Byte
+            return a.intValue() - b.intValue();
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof SubtractAtom)) return false;
+        return super.equals(obj);
+    }
+}

--- a/com/example/metta/interpreter/InterpreterExamplesTest.java
+++ b/com/example/metta/interpreter/InterpreterExamplesTest.java
@@ -64,25 +64,25 @@ public class InterpreterExamplesTest {
         // For now, let's test a non-recursive part or a very simple one if arithmetic isn't there.
         // Test: (eval (fact 0)) -> 1
         List<String> resultsFact0 = interpretToStr(space, "(eval (fact 0))");
-        assertEquals(List.of("1"), resultsFact0); 
+        // This will now work if arithmetic ops are parsed correctly
+        // assertEquals(List.of("1"), resultsFact0); // Original assertion before arithmetic
 
-        // Test: (eval (fact 1)) -> (* 1 (fact (- 1 1))) -> (* 1 (fact 0))
-        // If * and - are not executable, this will be the result.
-        // This requires (fact 0) to be resolved first by the chain of eval.
-        // The current handleEval for expressions tries to execute grounded operators.
-        // If '*' and '-' are symbols, it will try to query them.
-        // This test is too complex without arithmetic.
-        // Let's simplify.
+        // With arithmetic, (fact 0) should work.
+        // Let's test this properly in arithmeticOperationsTest and keep this as is for now,
+        // or update it if we confirm arithmetic is available at this stage of test execution.
+        // For now, the original test logic for (fact 0) without full arithmetic support:
+        // if arithmetic is not yet fully working in this old test, it might yield "1" if (= (fact 0) 1) is directly matched.
+        // if SExprParser changes how `*` and `-` are parsed globally, this test might change behavior.
+        // Assuming this test was written when `*` and `-` were just symbols.
+        // The new arithmetic tests will cover the (fact $n) with actual computation.
+        // Let's update this test to reflect that (fact 0) should simply return 1 due to the direct rule.
+        assertEquals(List.of("1"), resultsFact0);
+
+
         GroundingSpace space2 = createSpace("(= (next A) B) (= (next B) C)");
         List<String> resultsNextA = interpretToStr(space2, "(eval (next A))");
         assertEquals(List.of("B"), resultsNextA);
         
-        // Test evaluation of (next (next A)) assuming eval is recursive enough.
-        // (eval (next (next A)))
-        // -> (eval (next B))  -- because (next A) -> B from above
-        // -> C                -- because (next B) -> C
-        // This requires the result of an inner eval to be used in an outer eval,
-        // which the current Interpreter structure (frames and return handlers) should support.
         List<String> resultsNextNextA = interpretToStr(space2, "(eval (next (next A)))");
          assertEquals(List.of("C"), resultsNextNextA);
     }
@@ -94,26 +94,14 @@ public class InterpreterExamplesTest {
         List<String> results = interpretToStr(space, "(chain (eval (get-val)) $x (result $x))");
         assertEquals(List.of("(result VAL)"), results);
 
-        // Test chain with no result from nested
         GroundingSpace emptySpace = createSpace("");
         List<String> resultsNoVal = interpretToStr(emptySpace, "(chain (eval (get-val-missing)) $x (result $x))");
-        // (eval (get-val-missing)) -> (get-val-missing)
-        // then $x = (get-val-missing)
-        // then (result (get-val-missing))
-        // then (eval (result (get-val-missing))) -> (result (get-val-missing))
         assertEquals(List.of("(result (get-val-missing))"), resultsNoVal);
     }
     
     @Test
     void chainWithFurtherEval() {
         GroundingSpace space = createSpace("(= (get-val) (computation-needed)) (= (computation-needed) RESULT)");
-        // (chain (eval (get-val)) $x (eval $x))
-        // 1. (eval (get-val)) -> (computation-needed)
-        // 2. $x = (computation-needed)
-        // 3. template becomes (eval (computation-needed))
-        // 4. (eval (eval (computation-needed)))
-        //    - inner (eval (computation-needed)) -> RESULT
-        //    - outer (eval RESULT) -> RESULT
         List<String> results = interpretToStr(space, "(chain (eval (get-val)) $x (eval $x))");
         assertEquals(List.of("RESULT"), results);
     }
@@ -121,174 +109,140 @@ public class InterpreterExamplesTest {
 
     @Test
     void unifyOperation() {
-        GroundingSpace space = createSpace(""); // Unify does not need space content for this test
+        GroundingSpace space = createSpace("");
         
-        // (unify (A $x) (A B) (then $x) (else)) -> (then B)
         List<String> resultsMatch = interpretToStr(space, "(unify (A $x) (A B) (then $x) (else))");
         assertEquals(List.of("(then B)"), resultsMatch);
 
-        // (unify (A C) (A B) (then $x) (else)) -> (else)
         List<String> resultsNoMatch = interpretToStr(space, "(unify (A C) (A B) (then $x) (else))");
         assertEquals(List.of("(else)"), resultsNoMatch);
         
-        // Unify with no variables in 'then' branch, but bindings should still apply if vars were there
         List<String> resultsSimpleThen = interpretToStr(space, "(unify (A $x) (A B) (success) (failure))");
         assertEquals(List.of("(success)"), resultsSimpleThen);
     }
     
-    // Decons/Cons were specified as decons-atom / cons-atom in plan step 5,
-    // but MettaSymbols uses DECONS_SYMBOL ("decons") and CONS_SYMBOL ("cons").
-    // Assuming "decons" and "cons" are the correct operator names now.
     @Test
     void deconsAndConsOperations() {
         GroundingSpace space = createSpace("");
 
-        // (decons (a b c) $x $y $z) -> binds $x=a, $y=b, $z=c. Result is (a b c).
-        // The actual result of (decons ...) operation is the expression itself if successful for further use.
-        // Or, often it's used within a `chain` or `unify` where bindings matter.
-        // For direct `eval` of `decons`, the current impl returns the matched expression.
         List<String> deconsResults = interpretToStr(space, "(eval (decons (a b c) $x $y $z))");
-        // This is tricky: what should (eval (decons ...)) return?
-        // The decons handler marks the frame as finished with currentAtom = targetExpr (a b c)
-        // and newBindings including $x=a etc.
-        // So, (eval (decons ...)) should yield (a b c).
-        // The bindings $x=a etc. are internal to that evaluation step and don't propagate upwards
-        // unless the overall expression was something like (chain (decons ...) $x ...).
         assertEquals(List.of("(a b c)"), deconsResults);
 
-        // Test decons failure (arity mismatch)
         List<String> deconsFail = interpretToStr(space, "(eval (decons (a b) $x $y $z))");
-        assertTrue(deconsFail.get(0).startsWith("(Error IncorrectArguments (decons (a b) $x $y $z))") || deconsFail.get(0).startsWith("(Error DeconsArityMismatch"));
+        assertTrue(deconsFail.get(0).startsWith("(Error DeconsArityMismatch") || deconsFail.get(0).startsWith("(Error IncorrectArguments (decons (a b) $x $y $z))"));
 
-
-        // (cons $x $y $z) with prior bindings $x=a, $y=b, $z=c -> (a b c)
-        // Need to achieve bindings first. Can use `chain` or `unify`.
-        // Let's use a query that establishes bindings for $x, $y, $z first.
-        // This is too complex for a direct cons test.
-        // Simpler: (eval (cons a b c)) -> (a b c)
         List<String> consResults = interpretToStr(space, "(eval (cons a b c))");
         assertEquals(List.of("(a b c)"), consResults);
 
-        // Test cons with variables that are bound by an outer context (e.g. unify)
-        // (unify (X Y) (X Y) (cons $x $y) (nevermind))
-        // This is slightly off, as $x, $y are not bound by (X Y).
-        // Let's test (chain (= (get-parts) (part1 part2)) $res (decons $res $A $B (cons $A $B))) -- too complex
-        // Simpler test for cons with bound vars, using nested eval with space:
-        // Space: (= (bind-vars) (unify (A $x) (A valX) (cons $x Y Z)))
-        // (eval (eval (bind-vars)))
-        // This level of indirection in testing `cons` is probably too much for "basic"
-        // The current `handleCons` applies bindings that are current in its frame.
-        // So, if we have `(chain ... $x (chain ... $y (cons $x $y)))` it would work.
-        // For a direct test:
-        // We need to make sure the test utility or a setup can provide initial bindings to an expression.
-        // The `interpret` utility doesn't take initial bindings.
-        // So, we rely on `cons` just using symbols as is if variables are not bound.
         List<String> consWithVars = interpretToStr(space, "(eval (cons $x $y))");
-        assertEquals(List.of("($x $y)"), consWithVars); // $x, $y are unbound, so used as literals
+        assertEquals(List.of("($x $y)"), consWithVars);
     }
     
     @Test
     void errorHandlingNotEnoughArgsForUnify() {
         GroundingSpace space = createSpace("");
-        // (unify (A B)) -> Error: IncorrectArguments
         List<String> results = interpretToStr(space, "(eval (unify (A B)))");
         assertEquals(1, results.size());
         assertTrue(results.get(0).startsWith("(Error IncorrectArguments"));
     }
 
-    // Turing Machine Example (Simplified)
-    // Rules adapted from Rust's busy-beaver example
-
     private final String turingMachineBaseRules =
-        // Core TM step function: (tm <TransitionFunction> <CurrentState> <Tape>)
-        // Tape: ( <LeftSymbolsReversed> <CurrentSymbol> <RightSymbols> )
         "(= (tm $F $S ($L $C $R)) (chain (eval ($F $S $C)) $res (eval (apply-tm-result $res ($L $C $R) $F))))" +
-        // apply-tm-result: takes (NewSymbol NewState Direction) and current tape+TF, yields new (tm ...) call or halts
         "(= (apply-tm-result ($NSym $NState $Dir) ($L $CSym $R) $F) (chain (eval (move $Dir ($L ($NSym) $R))) $newTape (tm $F $NState $newTape)))" +
-        // Special Halt state: if NewState is 'halt', the result is just the final tape.
         "(= (apply-tm-result ($NSym halt $Dir) ($L $CSym $R) $F) (chain (eval (move $Dir ($L ($NSym) $R))) $finalTape $finalTape))" +
-        // move left: (move L ( (l2 l1) (c) (r1 r2) )) -> ( (l2) (l1) (c r1 r2) )
-        // move L from empty left: (move L ( () (c) (r1 r2) )) -> ( () (blank) (c r1 r2) ) - assuming 'blank' symbol for empty tape cells
-        "(= (move L (($LH $LT) $C $R)) ($LT ($LH) ($C $R)))" + // Move head left, $LH becomes current
-        "(= (move L (() $C $R)) (() (blank) ($C $R)))" +     // Move head left from empty left tape, new blank appears
-        // move right: (move R ( (l1 l2) (c) (r1 r2) )) -> ( (c l1 l2) (r1) (r2) )
-        // move R from empty right: (move R ( (l1 l2) (c) () )) -> ( (c l1 l2) (blank) () )
-        "(= (move R ($L $C ($RH $RT))) (($C $L) ($RH) $RT))" + // Move head right, $RH becomes current
-        "(= (move R ($L $C ())) (($C $L) (blank) ()))";       // Move head right from empty right tape, new blank appears
+        "(= (move L (($LH $LT) $C $R)) ($LT ($LH) ($C $R)))" +
+        "(= (move L (() $C $R)) (() (blank) ($C $R)))" +
+        "(= (move R ($L $C ($RH $RT))) (($C $L) ($RH) $RT))" +
+        "(= (move R ($L $C ())) (($C $L) (blank) ()))";
 
-    // Busy Beaver 3-state 2-symbol rules (simplified notation for F S C -> NS NC D)
-    // States: A, B, C. Halt state: H (or 'halt' symbol). Symbols: 0, 1. Blank: 0 or 'blank'.
-    // Using 'blank' consistently.
     private final String busyBeaverRules =
-        "(= (busy-beaver A blank) (1 B R))" + // If in state A, see blank, write 1, goto B, move R
-        "(= (busy-beaver A 0)     (1 B R))" + // Same for 0 as blank
-        "(= (busy-beaver A 1)     (1 C L))" + // If in state A, see 1, write 1, goto C, move L
+        "(= (busy-beaver A blank) (1 B R))" +
+        "(= (busy-beaver A 0)     (1 B R))" +
+        "(= (busy-beaver A 1)     (1 C L))" +
         "(= (busy-beaver B blank) (1 A L))" +
         "(= (busy-beaver B 0)     (1 A L))" +
         "(= (busy-beaver B 1)     (1 B R))" +
         "(= (busy-beaver C blank) (1 B L))" +
         "(= (busy-beaver C 0)     (1 B L))" +
-        "(= (busy-beaver C 1)     (halt halt R))"; // If in state C, see 1, write 1, goto HALT, move R
-                                                 // Using (halt halt R) so it fits ($NSym $NState $Dir)
-                                                 // The $NSym 'halt' here is a dummy write for the halt transition.
+        "(= (busy-beaver C 1)     (halt halt R))";
 
     @Test
     void turingMachineSimplifiedStep() {
-        GroundingSpace space = createSpace(turingMachineBaseRules + busyBeaverRules + "(= blank blank)"); // blank symbol
+        GroundingSpace space = createSpace(turingMachineBaseRules + busyBeaverRules + "(= blank blank)");
         
-        // Initial state: (tm busy-beaver A (() blank ()))
-        // Tape: Left blank, Current blank, Right blank
-        // Expected first step: (busy-beaver A blank) -> (1 B R)
-        // Then: (apply-tm-result (1 B R) (() blank ()) busy-beaver)
-        // Then: (move R (() (1) ())) -> ((1) (blank) ())
-        // Then: (tm busy-beaver B ((1) (blank) ())) -> this is the state after one step.
-
-        // Let's try to interpret just one step, or a few, by limiting the query.
-        // The full `interpret` might run for too long or hit unimplemented parts.
-        // For now, let's use the main `interpret` and see.
-        // It's possible the simplified function handling (no real closures) might be an issue.
-        // The `tm` rule uses `eval ($F $S $C)` which becomes `(eval (busy-beaver A blank))`.
-        // This should resolve to `(1 B R)`.
-        // Then `chain` binds `$res = (1 B R)`.
-        // Then `(eval (apply-tm-result (1 B R) (() blank ()) busy-beaver))` is called.
-        // This seems plausible with current interpreter.
-
         List<String> results = interpretToStr(space, "(eval (tm busy-beaver A (() blank ())))");
         
-        // Expected final state for this busy beaver (BB-3) is 6 ones after 14 steps.
-        // Tape: ((1) (1) (1 1 1 1)) -- this is one representation of six 1s, current is the first 1.
-        // Or, more simply, a tape like: (... 1 1 1 1 1 1 ...)
-        // Example result from a Rust run: (((1 1 1) 1 (1 1)) H ((0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 00 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000_S_USER_CONTEXT_0
-        // Expected final state for this busy beaver (BB-3) is 6 ones after 14 steps.
-        // Tape: ((1 1 1) 1 (1 1))
-        // (tm busy-beaver halt tape) where tape is the final configuration.
-        // Let's check for the specific final configuration as a string
-        // The Rust test output is: (((1 1 1) 1 (1 1)) H R) - this is the content of $res before apply-tm-result for halt
-        // The final result of (eval (tm ...)) would be the tape itself via the halt rule.
-        // So, expected: "((1 1 1) 1 (1 1))"
-        // Note: The string representation of the tape might vary based on how many 'blank' symbols are kept or trimmed.
-        // The Rust example shows: (blank blank 1 1 1 1 1 1 blank blank) with head on one of the 1s.
-        // Let's use a known final configuration from a reliable source for BB-3 (2-symbol, 3-state):
-        // It produces six 1s on the tape. Example: ...01111110...
-        // If the tape is `(L C R)`, a representation could be `((1 1 1) 1 (1 1))` if head is on 4th 1.
-        // Or `(() 1 (1 1 1 1 1))` if head is on the first 1 and left is empty.
-        // The specific output format of the tape from my `move` rules will determine this.
-        // Let's assume the Rust output `((1 1 1) 1 (1 1))` is the target for the tape part of the final state.
-        // The halt rule `(= (apply-tm-result ($NSym halt $Dir) ($L $CSym $R) $F) (chain (eval (move $Dir ($L ($NSym) $R))) $finalTape $finalTape))`
-        // means the result of the whole `eval (tm ...)` is the final tape configuration.
-
-        // Due to potential differences in my simplified `move` rules (especially handling of `blank` at ends)
-        // and the exact number of steps/complexity, this test might be fragile or too slow.
-        // For now, I'll assert a plausible structure if it halts, or check for non-error / non-loop.
-        // If the interpreter is too slow or gets stuck, this test will time out or fail.
-        // For now, let's check if it produces *a* result that is an expression (the tape).
         assertFalse(results.isEmpty(), "Turing machine interpretation should produce a result.");
-        Atom resultAtom = atom(results.get(0)); // Parse the result string back to an atom
+        Atom resultAtom = atom(results.get(0));
         assertTrue(resultAtom instanceof ExpressionAtom, "Final result of TM should be a tape (ExpressionAtom)");
-        // A more specific assertion would be: assertEquals(List.of("((1 1 1) 1 (1 1))"), results);
-        // but this is highly dependent on the exact TM execution and my rule definitions.
-        // For now, let's confirm it's not an error and produces some tape structure.
         System.out.println("TM Result: " + results.get(0));
         assertFalse(results.get(0).startsWith("(Error"), "Turing machine execution should not result in an error");
+    }
+
+    @Test
+    void arithmeticOperationsTest() {
+        GroundingSpace space = createSpace(""); // Empty space for most direct eval tests
+
+        // Basic Integer Operations
+        assertEquals(List.of("5"), interpretToStr(space, "(eval (+ 2 3))"));
+        assertEquals(List.of("3"), interpretToStr(space, "(eval (- 5 2))"));
+        assertEquals(List.of("12"), interpretToStr(space, "(eval (* 3 4))"));
+
+        // Basic Floating Point Operations
+        assertEquals(List.of("6.0"), interpretToStr(space, "(eval (+ 2.5 3.5))"));
+        assertEquals(List.of("2.5"), interpretToStr(space, "(eval (- 5.0 2.5))"));
+        assertEquals(List.of("3.0"), interpretToStr(space, "(eval (* 1.5 2.0))"));
+        assertEquals(List.of("3.5"), interpretToStr(space, "(eval (+ 1 2.5))")); // Mixed types
+        assertEquals(List.of("-1.0"), interpretToStr(space, "(eval (- 1.0 2))")); // Mixed types subtraction
+
+        // Nested Operations
+        assertEquals(List.of("7"), interpretToStr(space, "(eval (+ 1 (* 2 3)))"));
+        assertEquals(List.of("12"), interpretToStr(space, "(eval (* (+ 1 2) (- 5 1)))"));
+        assertEquals(List.of("7.0"), interpretToStr(space, "(eval (+ 1.0 (* 2 3.0)))"));
+
+        // Operations with Variables (using rules)
+        GroundingSpace spaceArithVars = createSpace("(= (add-twice $x) (+ $x $x))");
+        assertEquals(List.of("6"), interpretToStr(spaceArithVars, "(eval (add-twice 3))"));
+        assertEquals(List.of("5.0"), interpretToStr(spaceArithVars, "(eval (add-twice 2.5))"));
+
+        // Factorial Example (Recursive)
+        GroundingSpace spaceFact = createSpace("(= (fact 0) 1) (= (fact $n) (* $n (fact (- $n 1))))");
+        assertEquals(List.of("1"), interpretToStr(spaceFact, "(eval (fact 0))"));
+        assertEquals(List.of("1"), interpretToStr(spaceFact, "(eval (fact 1))"));
+        assertEquals(List.of("2"), interpretToStr(spaceFact, "(eval (fact 2))"));
+        assertEquals(List.of("6"), interpretToStr(spaceFact, "(eval (fact 3))"));
+        assertEquals(List.of("120"), interpretToStr(spaceFact, "(eval (fact 5))"));
+
+        // Error Handling
+        List<String> errorResult;
+
+        // Incorrect number of arguments
+        errorResult = interpretToStr(space, "(eval (+ 1))");
+        assertEquals(1, errorResult.size(), "Expected one result for (+ 1)");
+        assertTrue(errorResult.get(0).startsWith("(Error IncorrectArguments +)"), "Error msg mismatch for (+ 1). Was: " + errorResult.get(0));
+
+        errorResult = interpretToStr(space, "(eval (- 1 2 3))");
+        assertEquals(1, errorResult.size(), "Expected one result for (- 1 2 3)");
+        assertTrue(errorResult.get(0).startsWith("(Error IncorrectArguments -)"), "Error msg mismatch for (- 1 2 3). Was: " + errorResult.get(0));
+
+        // Non-numeric arguments
+        errorResult = interpretToStr(space, "(eval (+ 1 A))");
+        assertEquals(1, errorResult.size(), "Expected one result for (+ 1 A)");
+        assertTrue(errorResult.get(0).startsWith("(Error NonNumericArguments + 1 A)"), "Error msg mismatch for (+ 1 A). Was: " + errorResult.get(0));
+
+        errorResult = interpretToStr(space, "(eval (* B C))");
+        assertEquals(1, errorResult.size(), "Expected one result for (* B C)");
+        assertTrue(errorResult.get(0).startsWith("(Error NonNumericArguments * B C)"), "Error msg mismatch for (* B C). Was: " + errorResult.get(0));
+
+        // Edge Cases
+        assertEquals(List.of("-1"), interpretToStr(space, "(eval (- 2 3))"));
+        assertEquals(List.of("0"), interpretToStr(space, "(eval (* 10 0))"));
+        assertEquals(List.of("0.0"), interpretToStr(space, "(eval (* 10 0.0))"));
+        assertEquals(List.of("0"), interpretToStr(space, "(eval (* 0 10))"));
+
+        // Test with larger numbers (Long)
+        assertEquals(List.of("3000000000"), interpretToStr(space, "(eval (* 300000 10000))")); // 3 * 10^9
+        assertEquals(List.of(Long.toString(Long.MAX_VALUE)), interpretToStr(space, "(eval (+ " + (Long.MAX_VALUE - 1) + " 1))" ));
+        assertEquals(List.of(Long.toString(Long.MIN_VALUE)), interpretToStr(space, "(eval (+ " + Long.MAX_VALUE + " 1))" ));
     }
 }

--- a/com/example/metta/text/SExprParser.java
+++ b/com/example/metta/text/SExprParser.java
@@ -124,6 +124,15 @@ public class SExprParser {
             case CLOSE_PAREN:
                 throw new SExprParserException("Unexpected ')'");
             case SYMBOL:
+                // Check for known operational symbols first
+                if (token.value.equals("+")) {
+                    return new AddAtom();
+                } else if (token.value.equals("-")) {
+                    return new SubtractAtom();
+                } else if (token.value.equals("*")) {
+                    return new MultiplyAtom();
+                }
+                // Default to SymbolAtom if not a special operational symbol
                 return new SymbolAtom(token.value);
             case VARIABLE:
                 return new VariableAtom(token.value);


### PR DESCRIPTION
This commit introduces support for basic arithmetic operations within the MeTTa interpreter.

Key changes include:
- Definition of `AddAtom`, `SubtractAtom`, and `MultiplyAtom` as executable `GroundedAtom`s.
- Creation of an `AbstractBinaryOperatorAtom` base class to centralize common logic for binary numeric operations, including argument validation (count and type) and error reporting. The concrete arithmetic atoms extend this base class.
- Modification of `SExprParser` to directly parse `+`, `-`, and `*` symbols into their respective executable Atom instances (`AddAtom`, `SubtractAtom`, `MultiplyAtom`).
- Addition of a comprehensive test suite (`arithmeticOperationsTest`) in `InterpreterExamplesTest.java`. These tests cover:
    - Basic integer and floating-point calculations.
    - Mixed-type operations.
    - Nested arithmetic expressions.
    - Use of arithmetic operations within rules with variables.
    - A recursive factorial example (`(fact $n)`) to demonstrate integration.
    - Error handling for incorrect argument counts and non-numeric inputs.
    - Edge cases such as negative results, multiplication by zero, and large number (long) operations, including overflow behavior.

This enhancement significantly expands the computational capabilities of the MeTTa interpreter, allowing for more complex symbolic reasoning and knowledge representation that involves numerical calculations.